### PR TITLE
Escaping json for params

### DIFF
--- a/ajax_select/fields.py
+++ b/ajax_select/fields.py
@@ -499,7 +499,7 @@ def plugin_options(channel,channel_name,widget_plugin_options,initial):
         channel = base64.b64encode(channel)
         po['source'] = reverse('ajax_lookup',kwargs={'channel': channel})
     return {
-        'plugin_options': mark_safe(simplejson.dumps(po)),
+        'plugin_options': simplejson.dumps(po),
         # continue to support any custom templates that still expect these
         'lookup_url': po['source'],
         'min_length': po['min_length']


### PR DESCRIPTION
It is a mistake to mark as safe JSON that would be put in data-* attributes.
This data can contain quotes that would cause it to 'leak' into HTML.
The HTML-escaped data however is correctly handled by the browser.