### PR TITLE
fixed cascade fields initialization when parent is undefined

### DIFF
--- a/ajax_select/static/js/ajax_select.js
+++ b/ajax_select/static/js/ajax_select.js
@@ -337,8 +337,14 @@ var BobAjaxSelect = (function (window, undefined) {
                         }
                     });
                 };
-                // initialization of available choices, hence 'true' as third argument
-                getChoices(input, pk, true);
+                if(typeof pk === 'undefined'){
+                    // clear possible child choices if parent is undefined (ex. on empty, initial form)
+                    clearChoices(input);
+                }
+                else{
+                    // initialization of available choices, hence 'true' as third argument
+                    getChoices(input, pk, true);
+                }
                 if (parentDeck.length === 0) {
                     // parent field's widget is simple *select*
                     $('#' + $(input).data('parentId')).on('change', function () {


### PR DESCRIPTION
when parent of cascade fields is undefined clear child items (exactly as after "kill" of parent) instead of getting child items for it.